### PR TITLE
Symfony 4 support (breaking Symfony 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ matrix:
         - php: nightly
     fast_finish: true
 
+env:
+  matrix:
+    - PREFER_LOWEST="--prefer-lowest"
+    - PREFER_LOWEST=""
+
 cache:
     directories:
         - vendor
@@ -17,7 +22,7 @@ before_install:
     - phpenv config-rm xdebug.ini || true
 
 install:
-    - composer update --prefer-dist
+    - composer update --prefer-dist $PREFER_LOWEST
 
 script:
     - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
         "php": "^7.1",
 
         "behat/behat": "^3.1",
-        "symfony/dependency-injection": "^2.8|^3.0"
+        "symfony/dependency-injection": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
         "friends-of-behat/test-context": "^1.0",
         "phpspec/phpspec": "^4.0@alpha",
-        "symfony/http-kernel": "^2.8|^3.0",
+        "symfony/http-kernel": "^2.8|^3.0|^4.0",
         "phpunit/phpunit": "^5.7.13|^6.0"
     },
     "suggest": {
-        "symfony/http-kernel": "^2.8|^3.0"
+        "symfony/http-kernel": "^2.8|^3.0|^4.0"
     },
     "autoload": {
         "psr-4": { "FriendsOfBehat\\CrossContainerExtension\\": "src/" }

--- a/spec/ContainerBasedContainerAccessorSpec.php
+++ b/spec/ContainerBasedContainerAccessorSpec.php
@@ -41,7 +41,7 @@ final class ContainerBasedContainerAccessorSpec extends ObjectBehavior
 
     function it_gets_parameters_from_frozen_container(Container $container): void
     {
-        $container->isFrozen()->willReturn(true);
+        $container->isCompiled()->willReturn(true);
         $container->getParameterBag()->willReturn(new ParameterBag(['name' => 'value']));
 
         $this->getParameters()->shouldReturn(['name' => 'value']);
@@ -49,7 +49,7 @@ final class ContainerBasedContainerAccessorSpec extends ObjectBehavior
 
     function it_gets_parameters_from_not_frozen_container(Container $container): void
     {
-        $container->isFrozen()->willReturn(false);
+        $container->isCompiled()->willReturn(false);
         $container->getParameterBag()->willReturn(new ParameterBag(['name' => 'value']));
 
         $this->getParameters()->shouldReturn(['name' => 'value']);

--- a/spec/KernelBasedContainerAccessorSpec.php
+++ b/spec/KernelBasedContainerAccessorSpec.php
@@ -53,7 +53,7 @@ final class KernelBasedContainerAccessorSpec extends ObjectBehavior
     {
         $kernel->getContainer()->willReturn($container);
 
-        $container->isFrozen()->willReturn(true);
+        $container->isCompiled()->willReturn(true);
         $container->getParameterBag()->willReturn(new ParameterBag(['name' => 'value']));
 
         $this->getParameters()->shouldReturn(['name' => 'value']);
@@ -63,7 +63,7 @@ final class KernelBasedContainerAccessorSpec extends ObjectBehavior
     {
         $kernel->getContainer()->willReturn($container);
 
-        $container->isFrozen()->willReturn(false);
+        $container->isCompiled()->willReturn(false);
         $container->getParameterBag()->willReturn(new ParameterBag(['name' => 'value']));
 
         $this->getParameters()->shouldReturn(['name' => 'value']);

--- a/src/ContainerBasedContainerAccessor.php
+++ b/src/ContainerBasedContainerAccessor.php
@@ -45,7 +45,7 @@ final class ContainerBasedContainerAccessor implements ContainerAccessor
     {
         $parameterBag = $this->container->getParameterBag();
 
-        if (!$this->container->isFrozen()) {
+        if (!$this->container->isCompiled()) {
             $parameterBag = clone $parameterBag;
             $parameterBag->resolve();
         }

--- a/tests/CrossContainerProcessorTest.php
+++ b/tests/CrossContainerProcessorTest.php
@@ -29,12 +29,12 @@ final class CrossContainerProcessorTest extends TestCase
     public function it_resolves_cross_container_references_in_service_argument(): void
     {
         $externalContainer = new ContainerBuilder();
-        $externalContainer->setDefinition('array_object', new Definition(\ArrayObject::class, [['foo' => 'bar']]));
+        $externalContainer->setDefinition('array_object', (new Definition(\ArrayObject::class, [['foo' => 'bar']]))->setPublic(true));
 
         $baseContainer = new ContainerBuilder();
-        $baseContainer->setDefinition('array_object', new Definition(\ArrayObject::class, [
+        $baseContainer->setDefinition('array_object', (new Definition(\ArrayObject::class, [
             new Reference('__external__.array_object'),
-        ]));
+        ]))->setPublic(true));
 
         $this->buildContainerWithDependencies($baseContainer, ['external' => $externalContainer]);
 
@@ -48,12 +48,12 @@ final class CrossContainerProcessorTest extends TestCase
     public function it_resolves_cross_container_references_in_service_argument_array(): void
     {
         $externalContainer = new ContainerBuilder();
-        $externalContainer->setDefinition('std_class', new Definition(\stdClass::class));
+        $externalContainer->setDefinition('std_class', (new Definition(\stdClass::class))->setPublic(true));
 
         $baseContainer = new ContainerBuilder();
-        $baseContainer->setDefinition('array_object', new Definition(\ArrayObject::class, [
+        $baseContainer->setDefinition('array_object', (new Definition(\ArrayObject::class, [
             ['std' => ['class' => new Reference('__external__.std_class')]],
-        ]));
+        ]))->setPublic(true));
 
         $this->buildContainerWithDependencies($baseContainer, ['external' => $externalContainer]);
 
@@ -67,14 +67,14 @@ final class CrossContainerProcessorTest extends TestCase
     public function it_resolves_cross_container_references_in_service_argument_anonymous_definition(): void
     {
         $externalContainer = new ContainerBuilder();
-        $externalContainer->setDefinition('std_class', new Definition(\stdClass::class));
+        $externalContainer->setDefinition('std_class', (new Definition(\stdClass::class))->setPublic(true));
 
         $baseContainer = new ContainerBuilder();
-        $baseContainer->setDefinition('array_object', new Definition(\ArrayObject::class, [
+        $baseContainer->setDefinition('array_object', (new Definition(\ArrayObject::class, [
             new Definition(\ArrayObject::class, [
                 ['std_class' => new Reference('__external__.std_class')],
             ]),
-        ]));
+        ]))->setPublic(true));
 
         $this->buildContainerWithDependencies($baseContainer, ['external' => $externalContainer]);
 
@@ -88,11 +88,14 @@ final class CrossContainerProcessorTest extends TestCase
     public function it_resolves_cross_container_references_in_service_factory(): void
     {
         $externalContainer = new ContainerBuilder();
-        $externalContainer->setDefinition('array_object_factory', new Definition(\ArrayObject::class, [['old' => 'old']]));
+        $externalContainer->setDefinition('array_object_factory', (new Definition(\ArrayObject::class, [['old' => 'old']]))->setPublic(true));
 
         $baseContainer = new ContainerBuilder();
-        $baseContainer->setDefinition('array_object',
-            (new Definition(\ArrayObject::class, [['new' => 'new']]))->setFactory([new Reference('__external__.array_object_factory'), 'exchangeArray'])
+        $baseContainer->setDefinition(
+            'array_object',
+            (new Definition(\ArrayObject::class, [['new' => 'new']]))
+                ->setFactory([new Reference('__external__.array_object_factory'), 'exchangeArray'])
+                ->setPublic(true)
         );
 
         $this->buildContainerWithDependencies($baseContainer, ['external' => $externalContainer]);
@@ -142,9 +145,11 @@ final class CrossContainerProcessorTest extends TestCase
         $externalContainer->setParameter('parameter', '42');
 
         $baseContainer = new ContainerBuilder();
-        $baseContainer->setDefinition('array_object', new Definition(\ArrayObject::class, [
-            ['parameter' => '%__external__.parameter%'],
-        ]));
+        $baseContainer->setDefinition(
+            'array_object',
+            (new Definition(\ArrayObject::class, [['parameter' => '%__external__.parameter%']]))
+                ->setPublic(true)
+        );
 
         $this->buildContainerWithDependencies($baseContainer, ['external' => $externalContainer]);
 
@@ -190,10 +195,15 @@ final class CrossContainerProcessorTest extends TestCase
     public function it_resolves_cross_container_references_in_method_calls(): void
     {
         $externalContainer = new ContainerBuilder();
-        $externalContainer->setDefinition('array_object', new Definition(\ArrayObject::class, [['foo' => 'bar']]));
+        $externalContainer->setDefinition('array_object', (new Definition(\ArrayObject::class, [['foo' => 'bar']]))->setPublic(true));
 
         $baseContainer = new ContainerBuilder();
-        $baseContainer->setDefinition('array_object', (new Definition(\ArrayObject::class, [[]]))->addMethodCall('exchangeArray', [new Reference('__external__.array_object')]));
+        $baseContainer->setDefinition(
+            'array_object',
+            (new Definition(\ArrayObject::class, [[]]))
+                ->addMethodCall('exchangeArray', [new Reference('__external__.array_object')])
+                ->setPublic(true)
+        );
 
         $this->buildContainerWithDependencies($baseContainer, ['external' => $externalContainer]);
 
@@ -202,7 +212,7 @@ final class CrossContainerProcessorTest extends TestCase
     }
 
     /**
-     * @param ContainerBuilder $baseContainer
+     * @param ContainerBuilder   $baseContainer
      * @param ContainerBuilder[] $externalContainers
      */
     private function buildContainerWithDependencies(ContainerBuilder $baseContainer, array $externalContainers): void

--- a/tests/CrossContainerProcessorTest.php
+++ b/tests/CrossContainerProcessorTest.php
@@ -212,7 +212,7 @@ final class CrossContainerProcessorTest extends TestCase
     }
 
     /**
-     * @param ContainerBuilder   $baseContainer
+     * @param ContainerBuilder $baseContainer
      * @param ContainerBuilder[] $externalContainers
      */
     private function buildContainerWithDependencies(ContainerBuilder $baseContainer, array $externalContainers): void


### PR DESCRIPTION
Symfony 2 support has been broken because I had to replace `Container::isFrozen` by `Container::isCompiled`, because `Container::isFrozen` was deprecated in Symfony 3.2, and then removed in Symfony 4 ([associated PR](
https://api.symfony.com/3.4/Symfony/Component/DependencyInjection/Container.html#method_isFrozen)).