### PR TITLE
Ability to fetch private services

### DIFF
--- a/src/ContainerBasedContainerAccessor.php
+++ b/src/ContainerBasedContainerAccessor.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
  */
 
 namespace FriendsOfBehat\CrossContainerExtension;
-
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 final class ContainerBasedContainerAccessor implements ContainerAccessor
 {
@@ -25,7 +25,7 @@ final class ContainerBasedContainerAccessor implements ContainerAccessor
     /**
      * @param Container $container
      */
-    public function __construct(Container $container)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }

--- a/src/KernelBasedContainerAccessor.php
+++ b/src/KernelBasedContainerAccessor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FriendsOfBehat\CrossContainerExtension;
 
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 final class KernelBasedContainerAccessor implements ContainerAccessor
@@ -38,7 +39,11 @@ final class KernelBasedContainerAccessor implements ContainerAccessor
     {
         $container = $this->kernel->getContainer();
 
-        if (!$container instanceof Container) {
+        if ($container->has('test.service_container')) {
+            $container = $container->get('test.service_container');
+        }
+
+        if (!$container->has($id)) {
             throw new \DomainException('Could not get the services of kernel\'s container.');
         }
 


### PR DESCRIPTION
Since Symfony 4.1, private services can be fetched directly from the container in the tests as if they are public. ([ref](https://symfony.com/blog/new-in-symfony-4-1-simpler-service-testing))
This gives us the ability to inject private services from the Symfony container in our feature contexts.